### PR TITLE
Replace non-existent function with `verify_scheduler`

### DIFF
--- a/mcp/src/scheduler_manager.rs
+++ b/mcp/src/scheduler_manager.rs
@@ -539,7 +539,7 @@ impl SchedulerManager {
         log::info!("Verifying custom scheduler: {}", name);
 
         // Step 3: Verify the scheduler can load and run
-        let verification_result = self.generator.execute_scheduler(name, None).await
+        let verification_result = self.generator.verify_scheduler(name, None).await
             .map_err(|e| anyhow!("Failed to verify scheduler: {}", e))?;
 
         log::info!("Successfully created and verified scheduler: {}", name);


### PR DESCRIPTION
## Description

Running the command:
`cd mcp && cargo build --release && cd ..`

produces a compilation error because the function `execute_scheduler`
does not exist in the `SchedulerGenerator` object. Based on the comments
and parameter correspondence, it has been replaced with `verify_scheduler`
to ensure successful compilation and correct execution.

No issue was created for this change.

## Type of change

- [x] Bug fix (non-breaking change which fixes a compilation error)

## How Has This Been Tested?

- [x] Verified that `cd mcp && cargo build --release && cd ..` now compiles successfully
- [x] Ran the scheduler to confirm it executes correctly

**Test Configuration**:

- OS: Ubuntu 25.04 Plucky (Kernel 6.14.0-34-generic)
- CPU: 13th Gen Intel(R) Core(TM) i5-13500
- Memory: 32 GB RAM
- Toolchain: Rust 1.89.0, Cargo 1.89.0 (cargo build --release)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings